### PR TITLE
Fixing broken link

### DIFF
--- a/_sponsors/hak5.md
+++ b/_sponsors/hak5.md
@@ -2,5 +2,5 @@
 layout: page
 title: HAK5
 logo: "/images/hak5.png"
-website: www.hak5.org
+website: https://www.hak5.org/
 ---


### PR DESCRIPTION
On page https://bsidesroa.org/sponsors/

hak5 links to https://bsidesroa.org/sponsors/www.hak5.org

This should fix it