### PR TITLE
Set canonical link tag to bsidesroa.org

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -1,4 +1,5 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="canonical" href="https://bsidesroa.org">
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
 <link rel="manifest" href="/site.webmanifest">


### PR DESCRIPTION
Google is showing bsidesroanoke.github.io; This should fix that.