### PR TITLE
Fix talks page times and order + standardize across pages

### DIFF
--- a/src/components/FeaturedTalks.astro
+++ b/src/components/FeaturedTalks.astro
@@ -96,8 +96,8 @@ function getTimeSlot(talk: any) {
   const start = talk.data.startTime || talk.data.timeSlotStart;
   const end = talk.data.endTime || talk.data.timeSlotEnd;
   if (start && end) {
-    const startTime = new Date(start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    const endTime = new Date(end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const startTime = new Date(start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'America/New_York' });
+    const endTime = new Date(end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'America/New_York' });
     return `${startTime} - ${endTime}`;
   }
   // Fallback to legacy timeSlot field

--- a/src/components/ImprovedSchedule/ImprovedSchedule.tsx
+++ b/src/components/ImprovedSchedule/ImprovedSchedule.tsx
@@ -126,11 +126,11 @@ const TalkCard = ({ talk, onSelect }: { talk: Talk, onSelect: (talk: Talk) => vo
     // Convert ISO times to local time format with AM/PM
     if (time.includes('T')) {
       const date = new Date(time);
-      return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
+      return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/New_York' });
     }
     // Handle 24-hour format with AM/PM
     const date = new Date(`2000-01-01T${time}:00`);
-    return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', hour12: true });
+    return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: 'America/New_York' });
   };
 
   // Check if both start and end times are missing

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -59,8 +59,8 @@ function getTimeSlot(talk: any) {
 // Format time slot
 function formatTimeSlot(start: string | undefined, end: string | undefined) {
   if (!start || !end) return '';
-  const startTime = new Date(start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const endTime = new Date(end).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const startTime = new Date(start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'America/New_York' });
+  const endTime = new Date(end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'America/New_York' });
   return `${startTime} - ${endTime}`;
 }
 ---

--- a/src/pages/talks/[year].astro
+++ b/src/pages/talks/[year].astro
@@ -21,19 +21,16 @@ const pronounsMap = new Map(speakers.map(s => [s.id.replace(/\.md$/, ''), s.data
 const talks = (await getCollection('talks')).filter(talk => talk.data.eventSlug === year);
 const hasScheduledTalks = talks.some(talk => talk.data.startTime);
 const sortedTalks = talks.sort((a, b) => {
-  const dateA = a.data.date ? new Date(a.data.date) : null;
-  const dateB = b.data.date ? new Date(b.data.date) : null;
-
-  if (dateA && dateB) {
-    return dateB.getTime() - dateA.getTime();
+  const startA = a.data.startTime || a.data.timeSlotStart;
+  const startB = b.data.startTime || b.data.timeSlotStart;
+  
+  if (startA && startB) {
+    return new Date(startA).getTime() - new Date(startB).getTime();
   }
-  if (dateA) {
-    return -1;
-  }
-  if (dateB) {
-    return 1;
-  }
-  return 0;
+  if (startA) return -1;
+  if (startB) return 1;
+  
+  return (a.data.title || '').localeCompare(b.data.title || '');
 });
 
 ---
@@ -58,7 +55,7 @@ const sortedTalks = talks.sort((a, b) => {
           <div class="flex items-center space-x-4 text-sm font-semibold mb-4">
             <span class="text-gray-400">
               {data.startTime && data.endTime
-                ? `${new Date(data.startTime).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} - ${new Date(data.endTime).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
+                ? `${new Date(data.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' })} - ${new Date(data.endTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York' })}`
                 : 'TBD'}
             </span>
             <span class="text-accent-green">{data.room}</span>


### PR DESCRIPTION
Fixed the talk times displaying the wrong time zone and ensured it was consistent across layouts.
Updated talks page to be in time order rather than alphabetical.